### PR TITLE
Letter case - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ registerCpt(wp);
 Usage
 ------------
 ```js
-await wp.frontpage()
+await wp.frontPage()
 await wp.menu()
 await wp.slug()
 await wp.cpt('movies')


### PR DESCRIPTION
Case Sensitive function have wrong name and produce error. 
Proper name is in Pascal as follow this line: https://github.com/yashha/wpapi-extensions/blob/4bc5a01358cb07b7f81716eb75e962e6f66521ee/index.ts#L22