### PR TITLE
Remove warning "not found" - CommonJS compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
-    "build": "NODE_ENV=production parcel build index.ts",
+    "build": "NODE_ENV=production parcel build index.ts --experimental-scope-hoisting",
     "release": "standard-version && git push --follow-tags && yarn publish"
   },
   "devDependencies": {


### PR DESCRIPTION
Final solution for:
https://github.com/yashha/wpapi-extensions/issues/9
https://github.com/yashha/wp-nuxt/pull/114

It won't print any "not found" error as this transform file to browse/node/webpack/es6 compatible mode.
Same parcel, same dependency and additional flag that in simple scenario works fine.
Compatible with more package manager